### PR TITLE
fix: enforce audio file uploads

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,7 +12,17 @@ const port = process.env.PORT || 3000;
 const app = express();
 app.use(bodyParser.json());
 
-const upload = multer({ dest: 'uploads/', limits: {fileFilter: "audio/*"} });
+// Configure multer to accept only audio files
+const upload = multer({
+    dest: 'uploads/',
+    fileFilter: (req, file, cb) => {
+        if (file.mimetype && file.mimetype.startsWith('audio/')) {
+            cb(null, true);
+        } else {
+            cb(new Error('Only audio files are allowed'));
+        }
+    },
+});
 
 app.post('/webhook', upload.single('file'), handleWebhook);
 


### PR DESCRIPTION
## Summary
- ensure multer only accepts audio files to prevent invalid uploads

## Testing
- `npm test` (fails: Missing script)
- `node main.js` (fails: The OPENAI_API_KEY environment variable is missing or empty)

------
https://chatgpt.com/codex/tasks/task_e_6897200b1f4c83229ac6eec54af33c00